### PR TITLE
 Scale factor exposed to clients + added ListView as an option for displaying elements in contentDrawer

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,7 +14,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,45 +32,45 @@ class _AppState extends State<App> {
   bool get _isHeadContent => type == SlideDrawerExampleType.HEAD_CONTENT_DRAWER;
   bool get _isFullDrawer => type == SlideDrawerExampleType.FULL_DRAWER;
 
-  List<MenuItem> get _items => [
-        MenuItem('Basic',
+  List<DrawerMenuItem> get _items => [
+        DrawerMenuItem('Basic',
             onTap: () => _changeType(SlideDrawerExampleType.BASIC)),
-        MenuItem('Custom Background',
+        DrawerMenuItem('Custom Background',
             onTap: () => _changeType(SlideDrawerExampleType.BACKGROUND)),
-        MenuItem('Custom Gradient',
+        DrawerMenuItem('Custom Gradient',
             onTap: () => _changeType(SlideDrawerExampleType.GRADIENT)),
-        MenuItem('Custom Header',
+        DrawerMenuItem('Custom Header',
             onTap: () => _changeType(SlideDrawerExampleType.HEAD_DRAWER)),
-        MenuItem('Custom Content',
+        DrawerMenuItem('Custom Content',
             onTap: () => _changeType(SlideDrawerExampleType.CONTENT_DRAWER)),
-        MenuItem('Header and Content',
+        DrawerMenuItem('Header and Content',
             onTap: () =>
                 _changeType(SlideDrawerExampleType.HEAD_CONTENT_DRAWER)),
-        MenuItem('Full Drawer',
+        DrawerMenuItem('Full Drawer',
             onTap: () => _changeType(SlideDrawerExampleType.FULL_DRAWER)),
       ];
 
-  List<MenuItem> get _itemsIcon => [
-        MenuItem('Basic',
+  List<DrawerMenuItem> get _itemsIcon => [
+        DrawerMenuItem('Basic',
             icon: Icons.rss_feed,
             onTap: () => _changeType(SlideDrawerExampleType.BASIC)),
-        MenuItem('Custom Background',
+        DrawerMenuItem('Custom Background',
             icon: Icons.favorite_border,
             onTap: () => _changeType(SlideDrawerExampleType.BACKGROUND)),
-        MenuItem('Custom Gradient',
+        DrawerMenuItem('Custom Gradient',
             icon: Icons.mail_outline,
             onTap: () => _changeType(SlideDrawerExampleType.GRADIENT)),
-        MenuItem('Custom Header',
+        DrawerMenuItem('Custom Header',
             icon: Icons.map,
             onTap: () => _changeType(SlideDrawerExampleType.HEAD_DRAWER)),
-        MenuItem('Custom Content',
+        DrawerMenuItem('Custom Content',
             icon: Icons.person_outline,
             onTap: () => _changeType(SlideDrawerExampleType.CONTENT_DRAWER)),
-        MenuItem('Header and Content',
+        DrawerMenuItem('Header and Content',
             icon: Icons.alarm,
             onTap: () =>
                 _changeType(SlideDrawerExampleType.HEAD_CONTENT_DRAWER)),
-        MenuItem('Full Drawer',
+        DrawerMenuItem('Full Drawer',
             icon: Icons.settings,
             onTap: () => _changeType(SlideDrawerExampleType.FULL_DRAWER)),
       ];

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -73,7 +73,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -155,6 +155,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -80,7 +80,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:

--- a/lib/slide_drawer.dart
+++ b/lib/slide_drawer.dart
@@ -3,4 +3,4 @@ library slide_drawer;
 export './src/alignment.dart';
 export 'src/container.dart';
 export './src/drawer.dart';
-export './src/item.dart';
+export './src/drawer_menu_item.dart';

--- a/lib/src/container.dart
+++ b/lib/src/container.dart
@@ -86,7 +86,7 @@ class SlideDrawerContainer extends StatelessWidget {
       child: _hasDrawer
           ? drawer
           : Container(
-              height: MediaQuery.of(context).size.height,
+              height: useListView ? MediaQuery.of(context).size.height : null,
               decoration: _hasGradient
                   ? BoxDecoration(gradient: backgroundGradient)
                   : BoxDecoration(color: backgroundColor ?? theme.primaryColor),

--- a/lib/src/container.dart
+++ b/lib/src/container.dart
@@ -95,6 +95,7 @@ class SlideDrawerContainer extends StatelessWidget {
                   data: ThemeData(
                       brightness: brightness ?? theme.primaryColorBrightness),
                   child: useListView ? ListView(
+                    physics: ClampingScrollPhysics(),
                     children: _buildChildren,
                   ) : Column(
                         mainAxisAlignment: _isAlignTop

--- a/lib/src/container.dart
+++ b/lib/src/container.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:slide_drawer/src/alignment.dart';
-import 'package:slide_drawer/src/item.dart';
+import 'package:slide_drawer/src/drawer_menu_item.dart';
 
 import 'drawer.dart';
 
@@ -8,7 +8,7 @@ class SlideDrawerContainer extends StatelessWidget {
   final Widget? drawer;
   final Widget? head;
   final Widget? content;
-  final List<MenuItem> items;
+  final List<DrawerMenuItem> items;
   final double paddingRight;
   final bool useListView;
 
@@ -62,7 +62,7 @@ class SlideDrawerContainer extends StatelessWidget {
          child: content,
        ),
      if (!_hasContent && _hasItems)
-       for (MenuItem item in items)
+       for (DrawerMenuItem item in items)
          Container(
            margin: EdgeInsets.only(right: paddingRight),
            child: MenuItemWidget(item: item),
@@ -112,7 +112,7 @@ class SlideDrawerContainer extends StatelessWidget {
 }
 
 class MenuItemWidget extends StatelessWidget {
-  final MenuItem item;
+  final DrawerMenuItem item;
 
   MenuItemWidget({Key? key, required this.item}) : super(key: key);
 

--- a/lib/src/container.dart
+++ b/lib/src/container.dart
@@ -10,6 +10,7 @@ class SlideDrawerContainer extends StatelessWidget {
   final Widget? content;
   final List<MenuItem> items;
   final double paddingRight;
+  final bool useListView;
 
   /// The gradient to use for the background.
   ///
@@ -41,6 +42,7 @@ class SlideDrawerContainer extends StatelessWidget {
   SlideDrawerContainer({
     Key? key,
     required this.drawer,
+    required this.useListView,
     this.head,
     this.content,
     this.items = const [],
@@ -50,6 +52,23 @@ class SlideDrawerContainer extends StatelessWidget {
     this.alignment,
     this.paddingRight = 0,
   }) : super(key: key);
+
+  List<Widget> get _buildChildren {
+   return [
+     if (_hasHead) head!,
+     if (_hasContent)
+       Container(
+         margin: EdgeInsets.only(right: paddingRight),
+         child: content,
+       ),
+     if (!_hasContent && _hasItems)
+       for (MenuItem item in items)
+         Container(
+           margin: EdgeInsets.only(right: paddingRight),
+           child: MenuItemWidget(item: item),
+         )
+   ];
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -67,6 +86,7 @@ class SlideDrawerContainer extends StatelessWidget {
       child: _hasDrawer
           ? drawer
           : Container(
+              height: MediaQuery.of(context).size.height,
               decoration: _hasGradient
                   ? BoxDecoration(gradient: backgroundGradient)
                   : BoxDecoration(color: backgroundColor ?? theme.primaryColor),
@@ -74,25 +94,14 @@ class SlideDrawerContainer extends StatelessWidget {
                 child: Theme(
                   data: ThemeData(
                       brightness: brightness ?? theme.primaryColorBrightness),
-                  child: Column(
-                    mainAxisAlignment: _isAlignTop
-                        ? MainAxisAlignment.start
-                        : MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      if (_hasHead) head!,
-                      if (_hasContent)
-                        Container(
-                          margin: EdgeInsets.only(right: paddingRight),
-                          child: content,
-                        ),
-                      if (!_hasContent && _hasItems)
-                        for (MenuItem item in items)
-                          Container(
-                            margin: EdgeInsets.only(right: paddingRight),
-                            child: MenuItemWidget(item: item),
-                          ),
-                    ],
+                  child: useListView ? ListView(
+                    children: _buildChildren,
+                  ) : Column(
+                        mainAxisAlignment: _isAlignTop
+                            ? MainAxisAlignment.start
+                            : MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: _buildChildren,
                   ),
                 ),
               ),

--- a/lib/src/container.dart
+++ b/lib/src/container.dart
@@ -93,7 +93,7 @@ class SlideDrawerContainer extends StatelessWidget {
               child: SafeArea(
                 child: Theme(
                   data: ThemeData(
-                      brightness: brightness ?? theme.primaryColorBrightness),
+                      brightness: brightness ?? theme.brightness),
                   child: useListView ? ListView(
                     physics: ClampingScrollPhysics(),
                     children: _buildChildren,

--- a/lib/src/drawer.dart
+++ b/lib/src/drawer.dart
@@ -86,6 +86,9 @@ class SlideDrawer extends StatefulWidget {
   /// Default false
   final bool useListView;
 
+  /// If defined it will be called before dragging from left to right starts
+  final Function? beforeLeftToRightDrag;
+
   final Function? onWillPop;
 
   const SlideDrawer({
@@ -108,6 +111,7 @@ class SlideDrawer extends StatefulWidget {
     this.rotateAngle = (pi / 24),
     this.isRotate = true,
     this.useListView = false,
+    this.beforeLeftToRightDrag,
     this.onWillPop,
   }) : super(key: key);
 
@@ -178,6 +182,10 @@ class _SlideDrawerState extends State<SlideDrawer>
         _animation.isCompleted && details.globalPosition.dx > _maxDragStartEdge;
 
     _canBeDragged = isDragOpenFromLeft || isDragCloseFromRight;
+
+    if (isDragOpenFromLeft && widget.beforeLeftToRightDrag != null) {
+        widget.beforeLeftToRightDrag!();
+    }
   }
 
   _onDragUpdate(DragUpdateDetails details) {

--- a/lib/src/drawer.dart
+++ b/lib/src/drawer.dart
@@ -4,7 +4,7 @@ import 'package:curved_animation_controller/curved_animation_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:slide_drawer/src/alignment.dart';
 import 'package:slide_drawer/src/container.dart';
-import 'package:slide_drawer/src/item.dart';
+import 'package:slide_drawer/src/drawer_menu_item.dart';
 
 class SlideDrawer extends StatefulWidget {
   /// The gradient to use for the drawer background.
@@ -39,8 +39,8 @@ class SlideDrawer extends StatefulWidget {
   /// the default content drawer generated from [items]
   final Widget? contentDrawer;
 
-  /// List of [MenuItem] to be used to generate the default content drawer
-  final List<MenuItem> items;
+  /// List of [DrawerMenuItem] to be used to generate the default content drawer
+  final List<DrawerMenuItem> items;
 
   /// Duration of the drawer sliding animation
   ///

--- a/lib/src/drawer.dart
+++ b/lib/src/drawer.dart
@@ -170,11 +170,7 @@ class _SlideDrawerState extends State<SlideDrawer>
     _initAnimation();
   }
 
-  open() => _animation.start().then((_) {
-    if (widget.drawerJustOpened != null) {
-      widget.drawerJustOpened!();
-    }
-  });
+  open() => _animation.start().then((_) => _invokeDrawerJustOpened());
 
   close() => _animation.reverse();
   toggle() => isOpened ? close() : open();
@@ -201,6 +197,9 @@ class _SlideDrawerState extends State<SlideDrawer>
     double _kMinFlingVelocity = 365.0;
 
     if (_animation.isDismissed || _animation.isCompleted) {
+      if (_animation.isCompleted) {
+        _invokeDrawerJustOpened();
+      }
       return;
     }
 
@@ -208,16 +207,18 @@ class _SlideDrawerState extends State<SlideDrawer>
       double visualVelocity = details.velocity.pixelsPerSecond.dx /
           MediaQuery.of(context).size.width;
 
-      _animation.fling(velocity: visualVelocity).then((_) {
-        if (visualVelocity > 0 && widget.drawerJustOpened != null) {
-          widget.drawerJustOpened!();
-        }
-      });
+      _animation.fling(velocity: visualVelocity);
 
     } else if (_animation.value < 0.5) {
       close();
     } else {
       open();
+    }
+  }
+
+  void _invokeDrawerJustOpened() {
+    if (widget.drawerJustOpened != null) {
+      widget.drawerJustOpened!();
     }
   }
 

--- a/lib/src/drawer.dart
+++ b/lib/src/drawer.dart
@@ -81,6 +81,11 @@ class SlideDrawer extends StatefulWidget {
   /// Default is 0.25
   final double scale;
 
+  /// If set to true the view will be built using ListView rather than Column
+  ///
+  /// Default false
+  final bool useListView;
+
   final Function? onWillPop;
 
   const SlideDrawer({
@@ -102,6 +107,7 @@ class SlideDrawer extends StatefulWidget {
     this.offsetFromRight = 60.0,
     this.rotateAngle = (pi / 24),
     this.isRotate = true,
+    this.useListView = false,
     this.onWillPop,
   }) : super(key: key);
 
@@ -201,6 +207,7 @@ class _SlideDrawerState extends State<SlideDrawer>
   }
 
   Widget get _drawer => SlideDrawerContainer(
+        useListView: widget.useListView,
         alignment: widget.alignment,
         brightness: widget.brightness,
         backgroundColor: widget.backgroundColor,

--- a/lib/src/drawer.dart
+++ b/lib/src/drawer.dart
@@ -87,7 +87,7 @@ class SlideDrawer extends StatefulWidget {
   final bool useListView;
 
   /// If defined it will be called before dragging from left to right starts
-  final Function? beforeLeftToRightDrag;
+  final Function? drawerJustOpened;
 
   final Function? onWillPop;
 
@@ -111,7 +111,7 @@ class SlideDrawer extends StatefulWidget {
     this.rotateAngle = (pi / 24),
     this.isRotate = true,
     this.useListView = false,
-    this.beforeLeftToRightDrag,
+    this.drawerJustOpened,
     this.onWillPop,
   }) : super(key: key);
 
@@ -170,7 +170,12 @@ class _SlideDrawerState extends State<SlideDrawer>
     _initAnimation();
   }
 
-  open() => _animation.start();
+  open() => _animation.start().then((_) {
+    if (widget.drawerJustOpened != null) {
+      widget.drawerJustOpened!();
+    }
+  });
+
   close() => _animation.reverse();
   toggle() => isOpened ? close() : open();
 
@@ -183,9 +188,6 @@ class _SlideDrawerState extends State<SlideDrawer>
 
     _canBeDragged = isDragOpenFromLeft || isDragCloseFromRight;
 
-    if (isDragOpenFromLeft && widget.beforeLeftToRightDrag != null) {
-        widget.beforeLeftToRightDrag!();
-    }
   }
 
   _onDragUpdate(DragUpdateDetails details) {
@@ -206,7 +208,12 @@ class _SlideDrawerState extends State<SlideDrawer>
       double visualVelocity = details.velocity.pixelsPerSecond.dx /
           MediaQuery.of(context).size.width;
 
-      _animation.fling(velocity: visualVelocity);
+      _animation.fling(velocity: visualVelocity).then((_) {
+        if (visualVelocity > 0 && widget.drawerJustOpened != null) {
+          widget.drawerJustOpened!();
+        }
+      });
+
     } else if (_animation.value < 0.5) {
       close();
     } else {

--- a/lib/src/drawer.dart
+++ b/lib/src/drawer.dart
@@ -76,6 +76,11 @@ class SlideDrawer extends StatefulWidget {
   /// Default is [pi / 2]
   final double rotateAngle;
 
+  /// The factor by which the shifted content gets scaled by
+  ///
+  /// Default is 0.25
+  final double scale;
+
   final Function? onWillPop;
 
   const SlideDrawer({
@@ -93,6 +98,7 @@ class SlideDrawer extends StatefulWidget {
     this.reverseDuration,
     this.reverseCurve,
     this.alignment,
+    this.scale = 0.25,
     this.offsetFromRight = 60.0,
     this.rotateAngle = (pi / 24),
     this.isRotate = true,
@@ -208,13 +214,13 @@ class _SlideDrawerState extends State<SlideDrawer>
 
   Matrix4 get _transform => Matrix4.identity()
     ..translate(_maxSlide * _animation.value)
-    ..scale(1.0 - (0.25 * _animation.value))
+    ..scale(1.0 - (widget.scale * _animation.value))
     ..setEntry(3, 2, 0.001)
     ..rotateY(_animation.value * widget.rotateAngle);
 
   Matrix4 get _transformNoRotate => Matrix4.identity()
     ..translate(_maxSlide * _animation.value)
-    ..scale(1.0 - (0.25 * _animation.value));
+    ..scale(1.0 - (widget.scale * _animation.value));
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/drawer.dart
+++ b/lib/src/drawer.dart
@@ -207,7 +207,11 @@ class _SlideDrawerState extends State<SlideDrawer>
       double visualVelocity = details.velocity.pixelsPerSecond.dx /
           MediaQuery.of(context).size.width;
 
-      _animation.fling(velocity: visualVelocity);
+      _animation.fling(velocity: visualVelocity).then((value) {
+        if (visualVelocity > 0) {
+          _invokeDrawerJustOpened();
+        }
+      });
 
     } else if (_animation.value < 0.5) {
       close();

--- a/lib/src/drawer_menu_item.dart
+++ b/lib/src/drawer_menu_item.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-class MenuItem {
+class DrawerMenuItem {
   /// Widget to be used for the leading of [MenuTtemWidget]
   ///
   /// If this is null, then it will use Icon with IconData from [icon]
@@ -20,7 +20,7 @@ class MenuItem {
   bool get hasIcon => icon != null;
   bool get hasLeading => leading != null;
 
-  MenuItem(
+  DrawerMenuItem(
     this.title, {
     this.icon,
     this.leading,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -73,7 +73,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -134,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -148,6 +148,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -80,7 +80,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -99,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -134,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Two things in this PR.

- I have exposed the scale factor so that the client can decide to what extent the window shifted to the right gets resized (for it not to be resized at all use the value of 0.0) 

- In case the list of items held by the contentDrawer grows, the current implementation which is based on the Column will cause overflow warning and the last items in the column may not be visible (iPod touch simulator on iOS is a good example where that happens if the column contains 6 or more elements and the device is in landscape mode). In order to improve that I have added an option to build the view containing the items based on ListView that may be scrolled in case the list gets long.

All original functionality is retained and for the introduced changes to take any effect explicit changes in the client code need to be made or in other words, the existing code depending on this plugin should work exactly as before.